### PR TITLE
Updating baxter_moveit_config to specify use of the simple controller manager

### DIFF
--- a/baxter_moveit_config/config/baxter_controllers.yaml
+++ b/baxter_moveit_config/config/baxter_controllers.yaml
@@ -1,6 +1,7 @@
 controller_list:
   - name: /sdk/robot/limb/right
     ns: follow_joint_trajectory
+    type: FollowJointTrajectory
     default: true
     joints:
       - right_s0
@@ -12,6 +13,7 @@ controller_list:
       - right_w2
   - name: /sdk/robot/limb/left
     ns: follow_joint_trajectory
+    type: FollowJointTrajectory
     default: true
     joints:
       - left_s0

--- a/baxter_moveit_config/launch/baxter_moveit_controller_manager.launch
+++ b/baxter_moveit_config/launch/baxter_moveit_controller_manager.launch
@@ -1,18 +1,18 @@
 <launch>
 
   <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
-  <!-- arg name="moveit_controller_manager" default="pr2_moveit_controller_manager/Pr2MoveItControllerManager" /-->
-  <!-- param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/-->
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
+  <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
 
   <!-- The rest of the params are specific to this plugin -->
 
   <!-- If a controller manager is running (the generic one, not the MoveIt! one), we can talk to is via action interfaces.
        But we need to know its name. -->
-  <!-- arg name="controller_manager_name" default="pr2_controller_manager" /-->
-  <!-- param name="controller_manager_name" value="$(arg controller_manager_name)" /-->
+  <arg name="controller_manager_name" default="simple_controller_manager" />
+  <param name="controller_manager_name" value="$(arg controller_manager_name)" />
 
   <!-- Flag indicating whether the controller manager should be used or not -->
-  <arg name="use_controller_manager" default="false" />
+  <arg name="use_controller_manager" default="true" />
   <param name="use_controller_manager" value="$(arg use_controller_manager)" />
   
   <!-- load controller_list and controller_manager_ns -->


### PR DESCRIPTION
In support of the updates included in the v0.4.1 release of the moveit full deb.
