### PR TITLE
[iri_wam_moveit_config] Remove dependency to iri_wam_description package

### DIFF
--- a/iri_wam_moveit_config/package.xml
+++ b/iri_wam_moveit_config/package.xml
@@ -15,9 +15,6 @@
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
 
   <run_depend>moveit_ros_move_group</run_depend>
-  <build_depend>iri_wam_description</build_depend>
-  <run_depend>iri_wam_description</run_depend>
-
 
   <buildtool_depend>catkin</buildtool_depend>
   


### PR DESCRIPTION
Having this dependency forces people to install the iri_wam robot from svn which is not very practical. 
Until this dependency cannot be meet using rosdep I propose to avoid it.
