### PR TITLE
[baxter_moveit_config] add launch_sensor option to choose whether start sensor or not

### DIFF
--- a/baxter/baxter_moveit_config/launch/baxter_moveit_sensor_manager.launch
+++ b/baxter/baxter_moveit_config/launch/baxter_moveit_sensor_manager.launch
@@ -1,15 +1,16 @@
 <launch>
      <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>
+     <arg name="launch_sensor" default="true" />
      <arg name="kinect" default="false"/>
      <group if="$(arg kinect)" >
          <!-- launch openni to talk to kinect -->
-         <include file="$(find freenect_launch)/launch/freenect.launch">
+         <include if="$(arg launch_sensor)" file="$(find freenect_launch)/launch/freenect.launch">
              <!-- These args are workarounds for tf_prefix issues in freenect.launch -->
              <arg name="rgb_frame_id" value="camera_rgb_optical_frame"/>
              <arg name="depth_frame_id" value="camera_depth_optical_frame"/>
          </include>
          <!-- Users update this to set transform between camera and robot -->
-         <node pkg="tf" type="static_transform_publisher" name="camera_link_broadcaster"
+         <node  if="$(arg launch_sensor)" pkg="tf" type="static_transform_publisher" name="camera_link_broadcaster"
                args="$(arg camera_link_pose) /torso /camera_link 100" />
 
          <!-- octomap parameters for moveit -->
@@ -22,14 +23,14 @@
      <arg name="xtion" default="false"/>
      <group if="$(arg xtion)" >
          <!-- launch openni to talk to xtion -->
-         <include file="$(find openni_launch)/launch/openni.launch">
+         <include  if="$(arg launch_sensor)" file="$(find openni_launch)/launch/openni.launch">
              <!-- These args are workarounds for tf_prefix issues in openni.launch -->
              <arg name="rgb_frame_id" value="camera_rgb_optical_frame" />
              <arg name="depth_frame_id" value="camera_depth_optical_frame" />
          </include>
          <!-- Users update this to set transform between camera and robot -->
          <!-- This example has the Xtion mounted to the chest of the robot -->
-         <node pkg="tf" type="static_transform_publisher" name="camera_link_broadcaster"
+         <node  if="$(arg launch_sensor)" pkg="tf" type="static_transform_publisher" name="camera_link_broadcaster"
                args="$(arg camera_link_pose) /torso /camera_link 100" />
 
          <!-- octomap parameters for moveit -->

--- a/baxter/baxter_moveit_config/launch/demo_baxter.launch
+++ b/baxter/baxter_moveit_config/launch/demo_baxter.launch
@@ -12,10 +12,12 @@
   
   <!--node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" /-->
 
+  <arg name="launch_sensor" default="true"/>
   <arg name="kinect" default="false" />
   <arg name="xtion" default="false" />
   <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>
   <include file="$(find baxter_moveit_config)/launch/move_group.launch">
+    <arg name="launch_sensor" value="$(arg launch_sensor)" />
     <arg name="kinect" value="$(arg kinect)" />
     <arg name="xtion" value="$(arg xtion)" />
     <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>

--- a/baxter/baxter_moveit_config/launch/demo_kinect.launch
+++ b/baxter/baxter_moveit_config/launch/demo_kinect.launch
@@ -6,6 +6,7 @@
   <!-- Explicitly run moveit for baxter with the kinect -->
   <!-- Calls the demo_baxter launch file with the kinect argument set to true -->
   <include file="$(find baxter_moveit_config)/launch/demo_baxter.launch">
+    <arg name="launch_sensor" value="true"/>
     <arg name="kinect" value="true" />
     <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>
     <arg name="config" value="$(arg config)" />

--- a/baxter/baxter_moveit_config/launch/demo_xtion.launch
+++ b/baxter/baxter_moveit_config/launch/demo_xtion.launch
@@ -7,6 +7,7 @@
 
   <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>
   <include file="$(find baxter_moveit_config)/launch/demo_baxter.launch">
+    <arg name="launch_sensor" value="true"/>
     <arg name="xtion" value="true" />
     <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>
     <arg name="config" value="$(arg config)" />

--- a/baxter/baxter_moveit_config/launch/move_group.launch
+++ b/baxter/baxter_moveit_config/launch/move_group.launch
@@ -24,10 +24,12 @@
     <arg name="moveit_manage_controllers" value="true" />
   </include>
   
+  <arg name="launch_sensor" default="true" />
   <arg name="kinect" default="false" />
   <arg name="xtion" default="false" />
   <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>
   <include file="$(find baxter_moveit_config)/launch/sensor_manager.launch" if="$(arg allow_trajectory_execution)">
+    <arg name="launch_sensor" value="$(arg launch_sensor)" />
     <arg name="kinect" value="$(arg kinect)" />
     <arg name="xtion" value="$(arg xtion)" />
     <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>

--- a/baxter/baxter_moveit_config/launch/sensor_manager.launch
+++ b/baxter/baxter_moveit_config/launch/sensor_manager.launch
@@ -4,10 +4,12 @@
 
   <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
   <arg name="moveit_sensor_manager" default="baxter" />
+  <arg name="launch_sensor" default="true" />
   <arg name="kinect" default="false" />
   <arg name="xtion" default="false" />
   <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>
   <include file="$(find baxter_moveit_config)/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch" >
+    <arg name="launch_sensor" value="$(arg launch_sensor)" />
     <arg name="kinect" value="$(arg kinect)" />
     <arg name="xtion" value="$(arg xtion)" />
     <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>


### PR DESCRIPTION
I added launch_sensor args in launch files.
Default is true, but when you won't launch the sensor, you should set false.
This time, I added `if` condition to `static_transform_publisher` too.