### PR TITLE
Added Gripper construction Xacros for Baxter

### DIFF
--- a/baxter/baxter_moveit_config/config/baxter.srdf.xacro
+++ b/baxter/baxter_moveit_config/config/baxter.srdf.xacro
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<robot name="baxter" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="left_tip_name" default="left_gripper"/>
+  <xacro:arg name="right_tip_name" default="right_gripper"/>
+  <xacro:include filename="$(find baxter_moveit_config)/config/baxter_base.srdf.xacro" />
+  <xacro:baxter_base left_tip_name="$(arg left_tip_name)" right_tip_name="$(arg right_tip_name)"/>
+  <!--Left End Effector Collisions-->
+  <xacro:include filename="$(find baxter_moveit_config)/config/default_gripper.srdf.xacro" />
+  <xacro:default_gripper side="left"/>
+  <xacro:arg name="left_electric_gripper" default="false"/>
+  <xacro:if value="$(arg left_electric_gripper)">
+    <xacro:include filename="$(find baxter_moveit_config)/config/rethink_electric_gripper.srdf.xacro" />
+    <xacro:rethink_electric_gripper side="left"/>
+  </xacro:if>
+  <!--Right End Effector Collisions-->
+  <xacro:include filename="$(find baxter_moveit_config)/config/default_gripper.srdf.xacro" />
+  <xacro:default_gripper side="right"/>
+  <xacro:arg name="right_electric_gripper" default="false"/>
+  <xacro:if value="$(arg right_electric_gripper)">
+    <xacro:include filename="$(find baxter_moveit_config)/config/rethink_electric_gripper.srdf.xacro" />
+    <xacro:rethink_electric_gripper side="right"/>
+  </xacro:if>
+</robot>

--- a/baxter/baxter_moveit_config/config/baxter_base.srdf.xacro
+++ b/baxter/baxter_moveit_config/config/baxter_base.srdf.xacro
@@ -1,0 +1,286 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="baxter">
+  <xacro:macro name="baxter_base" params="left_tip_name right_tip_name">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <xacro:arg name="left_tip_name" default="left_gripper"/>
+    <xacro:arg name="right_tip_name" default="right_gripper"/>
+    <group name="left_arm">
+        <chain base_link="base" tip_link="$(arg left_tip_name)" />
+    </group>
+    <group name="right_arm">
+        <chain base_link="base" tip_link="$(arg right_tip_name)" />
+    </group>
+    <group name="both_arms">
+        <group name="right_arm" />
+        <group name="left_arm" />
+    </group>
+    <group name="left_hand">
+        <chain base_link="left_hand" tip_link="$(arg left_tip_name)" />
+    </group>
+    <group name="right_hand">
+        <chain base_link="right_hand" tip_link="$(arg right_tip_name)" />
+    </group>
+    <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
+    <end_effector name="left_hand_eef" parent_link="$(arg left_tip_name)" group="left_hand" parent_group="left_arm" />
+    <end_effector name="right_hand_eef" parent_link="$(arg right_tip_name)" group="right_hand" parent_group="right_arm" />
+    <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+    <group_state name="left_neutral" group="left_arm">
+        <joint name="left_e0" value="0" />
+        <joint name="left_e1" value="0.75" />
+        <joint name="left_s0" value="0" />
+        <joint name="left_s1" value="-0.55" />
+        <joint name="left_w0" value="0" />
+        <joint name="left_w1" value="1.26" />
+        <joint name="left_w2" value="0" />
+    </group_state>
+    <group_state name="right_neutral" group="right_arm">
+        <joint name="right_e0" value="0" />
+        <joint name="right_e1" value="0.75" />
+        <joint name="right_s0" value="0" />
+        <joint name="right_s1" value="-0.55" />
+        <joint name="right_w0" value="0" />
+        <joint name="right_w1" value="1.26" />
+        <joint name="right_w2" value="0" />
+    </group_state>
+    <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
+     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+    <virtual_joint name="world_joint" type="floating" parent_frame="world" child_link="torso" />
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="collision_head_link_1" link2="collision_head_link_2" reason="Adjacent" />
+    <disable_collisions link1="collision_head_link_1" link2="head" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="left_lower_shoulder" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="left_upper_elbow" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="left_upper_shoulder" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="pedestal" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="screen" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="collision_head_link_1" link2="torso" reason="Adjacent" />
+    <disable_collisions link1="collision_head_link_2" link2="head" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="left_upper_shoulder" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="pedestal" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="right_upper_elbow" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="screen" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="collision_head_link_2" link2="torso" reason="Adjacent" />
+    <disable_collisions link1="head" link2="left_hand_camera" reason="Never" />
+    <disable_collisions link1="head" link2="left_hand_range" reason="Never" />
+    <disable_collisions link1="head" link2="left_lower_shoulder" reason="Never" />
+    <disable_collisions link1="head" link2="left_upper_elbow" reason="Never" />
+    <disable_collisions link1="head" link2="left_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="head" link2="left_upper_shoulder" reason="Never" />
+    <disable_collisions link1="head" link2="pedestal" reason="Never" />
+    <disable_collisions link1="head" link2="right_hand_camera" reason="Never" />
+    <disable_collisions link1="head" link2="right_hand_range" reason="Never" />
+    <disable_collisions link1="head" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="head" link2="right_upper_elbow" reason="Never" />
+    <disable_collisions link1="head" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="head" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="head" link2="screen" reason="Adjacent" />
+    <disable_collisions link1="head" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="head" link2="torso" reason="Adjacent" />
+    <disable_collisions link1="left_hand" link2="left_hand_camera" reason="Adjacent" />
+    <disable_collisions link1="left_hand" link2="left_hand_range" reason="Adjacent" />
+    <disable_collisions link1="left_hand" link2="left_lower_elbow" reason="Never" />
+    <disable_collisions link1="left_hand" link2="left_lower_forearm" reason="Never" />
+    <disable_collisions link1="left_hand" link2="left_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="left_hand" link2="left_upper_forearm" reason="Never" />
+    <disable_collisions link1="left_hand" link2="left_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="left_hand" link2="left_wrist" reason="Adjacent" />
+    <disable_collisions link1="left_hand" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_hand" link2="left_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_hand_range" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_lower_elbow" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_lower_forearm" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_upper_elbow" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_upper_forearm" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="left_wrist" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="right_hand_camera" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="right_hand_range" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="right_lower_forearm" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="screen" reason="Never" />
+    <disable_collisions link1="left_hand_camera" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="left_lower_elbow" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="left_lower_forearm" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="left_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="left_upper_forearm" reason="Never" />
+    <disable_collisions link1="left_wrist" link2="left_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="left_wrist" link2="left_hand" reason="Never" />
+    <disable_collisions link1="left_wrist" link2="left_upper_forearm" reason="Never" />
+    <disable_collisions link1="left_wrist" link2="left_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="left_wrist" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_wrist" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="left_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="left_wrist" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="right_hand_camera" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="right_hand_range" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="screen" reason="Never" />
+    <disable_collisions link1="left_hand_range" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="left_lower_elbow" link2="left_lower_forearm" reason="Never" />
+    <disable_collisions link1="left_lower_elbow" link2="left_lower_shoulder" reason="Never" />
+    <disable_collisions link1="left_lower_elbow" link2="left_upper_elbow" reason="Adjacent" />
+    <disable_collisions link1="left_lower_elbow" link2="left_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="left_lower_elbow" link2="left_upper_forearm" reason="Adjacent" />
+    <disable_collisions link1="left_lower_elbow" link2="left_upper_forearm_visual" reason="Adjacent" />
+    <disable_collisions link1="left_lower_elbow" link2="left_wrist" reason="Never" />
+    <disable_collisions link1="left_lower_elbow" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="left_lower_elbow" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="left_lower_forearm" link2="left_lower_shoulder" reason="Never" />
+    <disable_collisions link1="left_lower_forearm" link2="left_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="left_lower_forearm" link2="left_upper_forearm" reason="Adjacent" />
+    <disable_collisions link1="left_lower_forearm" link2="left_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="left_lower_forearm" link2="left_wrist" reason="Adjacent" />
+    <disable_collisions link1="left_lower_forearm" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="left_lower_forearm" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="torso" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="left_upper_elbow" reason="Adjacent" />
+    <disable_collisions link1="left_lower_shoulder" link2="left_upper_elbow_visual" reason="Adjacent" />
+    <disable_collisions link1="left_lower_shoulder" link2="left_upper_forearm" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="left_upper_shoulder" reason="Adjacent" />
+    <disable_collisions link1="left_lower_shoulder" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="right_upper_elbow" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="screen" reason="Never" />
+    <disable_collisions link1="left_lower_shoulder" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="left_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="left_upper_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="right_upper_elbow" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="screen" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="left_upper_elbow" link2="torso" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="left_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="left_upper_forearm" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="left_upper_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="left_wrist" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_elbow_visual" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="left_upper_forearm" link2="left_upper_forearm_visual" reason="Default" />
+    <disable_collisions link1="left_upper_forearm" link2="left_wrist" reason="Never" />
+    <disable_collisions link1="left_upper_forearm" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_upper_forearm_visual" link2="torso" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="pedestal" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="right_lower_elbow" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="right_upper_elbow" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="screen" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="left_upper_shoulder" link2="torso" reason="Adjacent" />
+    <disable_collisions link1="pedestal" link2="right_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="pedestal" link2="right_hand_camera" reason="Default" />
+    <disable_collisions link1="pedestal" link2="right_hand_range" reason="Default" />
+    <disable_collisions link1="pedestal" link2="right_lower_elbow" reason="Default" />
+    <disable_collisions link1="pedestal" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="pedestal" link2="right_upper_elbow" reason="Never" />
+    <disable_collisions link1="pedestal" link2="right_upper_forearm" reason="Never" />
+    <disable_collisions link1="pedestal" link2="right_upper_forearm_visual" reason="Default" />
+    <disable_collisions link1="pedestal" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="pedestal" link2="left_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="pedestal" link2="left_hand_camera" reason="Default" />
+    <disable_collisions link1="pedestal" link2="left_hand_range" reason="Default" />
+    <disable_collisions link1="pedestal" link2="left_lower_elbow" reason="Default" />
+    <disable_collisions link1="pedestal" link2="left_lower_shoulder" reason="Never" />
+    <disable_collisions link1="pedestal" link2="left_upper_elbow" reason="Never" />
+    <disable_collisions link1="pedestal" link2="left_upper_forearm" reason="Never" />
+    <disable_collisions link1="pedestal" link2="left_upper_forearm_visual" reason="Default" />
+    <disable_collisions link1="pedestal" link2="left_upper_shoulder" reason="Never" />
+    <disable_collisions link1="pedestal" link2="screen" reason="Never" />
+    <disable_collisions link1="pedestal" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="pedestal" link2="torso" reason="Adjacent" />
+    <disable_collisions link1="right_hand" link2="right_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="right_hand" link2="right_hand_camera" reason="Adjacent" />
+    <disable_collisions link1="right_hand" link2="right_hand_range" reason="Adjacent" />
+    <disable_collisions link1="right_hand" link2="right_lower_elbow" reason="Never" />
+    <disable_collisions link1="right_hand" link2="right_lower_forearm" reason="Never" />
+    <disable_collisions link1="right_hand" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="right_hand" link2="right_upper_forearm" reason="Never" />
+    <disable_collisions link1="right_hand" link2="right_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="right_hand" link2="right_wrist" reason="Adjacent" />
+    <disable_collisions link1="right_hand" link2="pedestal" reason="Never" />
+    <disable_collisions link1="right_hand" link2="right_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="right_hand_range" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="right_lower_elbow" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="right_lower_forearm" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="right_upper_forearm" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="right_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="right_wrist" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="screen" reason="Never" />
+    <disable_collisions link1="right_hand_camera" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="right_lower_elbow" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="right_lower_forearm" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="right_upper_elbow" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="right_upper_forearm" reason="Never" />
+    <disable_collisions link1="right_wrist" link2="right_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="right_wrist" link2="right_upper_forearm" reason="Never" />
+    <disable_collisions link1="right_wrist" link2="right_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="right_wrist" link2="pedestal" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="right_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="right_wrist" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="screen" reason="Never" />
+    <disable_collisions link1="right_hand_range" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="right_lower_elbow" link2="right_lower_forearm" reason="Never" />
+    <disable_collisions link1="right_lower_elbow" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="right_lower_elbow" link2="right_upper_elbow" reason="Adjacent" />
+    <disable_collisions link1="right_lower_elbow" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="right_lower_elbow" link2="right_upper_forearm" reason="Adjacent" />
+    <disable_collisions link1="right_lower_elbow" link2="right_upper_forearm_visual" reason="Adjacent" />
+    <disable_collisions link1="right_lower_elbow" link2="right_wrist" reason="Never" />
+    <disable_collisions link1="right_lower_elbow" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="right_lower_forearm" link2="right_lower_shoulder" reason="Never" />
+    <disable_collisions link1="right_lower_forearm" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="right_lower_forearm" link2="right_upper_forearm" reason="Adjacent" />
+    <disable_collisions link1="right_lower_forearm" link2="right_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="right_lower_forearm" link2="right_wrist" reason="Adjacent" />
+    <disable_collisions link1="right_lower_forearm" link2="pedestal" reason="Never" />
+    <disable_collisions link1="right_lower_shoulder" link2="torso" reason="Never" />
+    <disable_collisions link1="right_lower_shoulder" link2="right_upper_elbow" reason="Adjacent" />
+    <disable_collisions link1="right_lower_shoulder" link2="right_upper_elbow_visual" reason="Adjacent" />
+    <disable_collisions link1="right_lower_shoulder" link2="right_upper_forearm" reason="Never" />
+    <disable_collisions link1="right_lower_shoulder" link2="right_upper_shoulder" reason="Adjacent" />
+    <disable_collisions link1="right_lower_shoulder" link2="screen" reason="Never" />
+    <disable_collisions link1="right_lower_shoulder" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="right_upper_elbow" link2="right_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="right_upper_elbow" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="right_upper_elbow" link2="screen" reason="Never" />
+    <disable_collisions link1="right_upper_elbow" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="right_upper_elbow" link2="torso" reason="Never" />
+    <disable_collisions link1="right_upper_elbow_visual" link2="right_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="right_upper_elbow_visual" link2="right_upper_shoulder" reason="Never" />
+    <disable_collisions link1="right_upper_elbow_visual" link2="right_wrist" reason="Never" />
+    <disable_collisions link1="right_upper_elbow_visual" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="right_upper_elbow_visual" link2="right_upper_forearm" reason="Never" />
+    <disable_collisions link1="right_upper_elbow_visual" link2="pedestal" reason="Never" />
+    <disable_collisions link1="right_upper_forearm" link2="right_upper_forearm_visual" reason="Default" />
+    <disable_collisions link1="right_upper_forearm" link2="right_wrist" reason="Never" />
+    <disable_collisions link1="right_upper_forearm_visual" link2="torso" reason="Never" />
+    <disable_collisions link1="right_upper_shoulder" link2="screen" reason="Never" />
+    <disable_collisions link1="right_upper_shoulder" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="right_upper_shoulder" link2="torso" reason="Adjacent" />
+    <disable_collisions link1="screen" link2="sonar_ring" reason="Never" />
+    <disable_collisions link1="screen" link2="torso" reason="Never" />
+    <disable_collisions link1="sonar_ring" link2="torso" reason="Adjacent" />
+</xacro:macro>
+</robot>

--- a/baxter/baxter_moveit_config/config/default_gripper.srdf.xacro
+++ b/baxter/baxter_moveit_config/config/default_gripper.srdf.xacro
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="default_gripper">
+    <xacro:macro name="default_gripper" params="side">
+    <disable_collisions link1="head" link2="${side}_gripper" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_hand" reason="Adjacent" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_hand_camera" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_hand_range" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_lower_elbow" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_lower_forearm" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_upper_forearm" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_wrist" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_hand_camera" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_hand_range" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="screen" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="sonar_ring" reason="Never" />
+
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="${side}_hand"         link2="${side}_gripper_base" reason="Adjacent" />
+    <disable_collisions link1="${side}_wrist"        link2="${side}_gripper_base" reason="Never" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_hand" reason="Default" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_hand_camera" reason="Default" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_hand_range" reason="Default" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_lower_elbow" reason="Never" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_lower_forearm" reason="Never" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_upper_forearm" reason="Never" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_wrist" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_gripper_base" reason="Default" />
+
+    <disable_collisions link1="${side}_gripper_base" link2="pedestal" reason="Default" />
+    <disable_collisions link1="${side}_gripper"      link2="pedestal" reason="Never" />
+
+    </xacro:macro>
+</robot>

--- a/baxter/baxter_moveit_config/config/rethink_electric_gripper.srdf.xacro
+++ b/baxter/baxter_moveit_config/config/rethink_electric_gripper.srdf.xacro
@@ -1,0 +1,69 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rethink_electric_gripper">
+    <xacro:macro name="rethink_electric_gripper" params="side">
+    <xacro:property name="gripper_side" value="${side[0]}" scope="local"/>
+
+    <disable_collisions link1="${side}_gripper_base" link2="${gripper_side}_gripper_l_finger" reason="Adjacent" />
+    <disable_collisions link1="${side}_gripper_base" link2="${gripper_side}_gripper_l_finger_tip" reason="Never" />
+    <disable_collisions link1="${side}_gripper_base" link2="${gripper_side}_gripper_r_finger" reason="Adjacent" />
+    <disable_collisions link1="${side}_gripper_base" link2="${gripper_side}_gripper_r_finger_tip" reason="Never" />
+
+    <disable_collisions link1="${side}_gripper" link2="${gripper_side}_gripper_l_finger" reason="Default" />
+    <disable_collisions link1="${side}_gripper" link2="${gripper_side}_gripper_l_finger_tip" reason="Never" />
+    <disable_collisions link1="${side}_gripper" link2="${gripper_side}_gripper_r_finger" reason="Default" />
+    <disable_collisions link1="${side}_gripper" link2="${gripper_side}_gripper_r_finger_tip" reason="Never" />
+
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${gripper_side}_gripper_l_finger_tip" reason="Adjacent" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${gripper_side}_gripper_r_finger" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${gripper_side}_gripper_r_finger_tip" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_hand" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_hand_camera" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_hand_range" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_lower_elbow" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_lower_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_upper_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${side}_wrist" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${gripper_side}_gripper_r_finger" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_hand" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_hand_camera" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_hand_range" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_lower_elbow" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_lower_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_upper_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${side}_wrist" reason="Never" />
+
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${gripper_side}_gripper_r_finger_tip" reason="Adjacent" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_hand" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_hand_camera" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_hand_range" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_lower_elbow" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_lower_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_upper_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${side}_wrist" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_hand" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_hand_accelerometer" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_hand_camera" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_hand_range" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_lower_elbow" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_lower_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_upper_elbow_visual" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_upper_forearm" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_upper_forearm_visual" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger_tip" link2="${side}_wrist" reason="Never" />
+
+    <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${gripper_side}_gripper_r_finger_tip" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${gripper_side}_gripper_l_finger_tip" reason="Never" />
+    <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${gripper_side}_gripper_r_finger_tip" reason="Never" />
+    </xacro:macro>
+</robot>

--- a/baxter/baxter_moveit_config/launch/baxter_grippers.launch
+++ b/baxter/baxter_moveit_config/launch/baxter_grippers.launch
@@ -1,28 +1,24 @@
+<?xml version="1.0"?>
 <launch>
   <arg name="config" default="true"/>
   <arg name="rviz_config" default="$(find baxter_moveit_config)/launch/moveit.rviz" />
 
+  <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
+  <arg name="load_robot_description" default="false"/>
   <!-- Left and right electric gripper params. Set to true to check for collisions for their links -->
-  <arg name="right_electric_gripper" default="false"/>
-  <arg name="left_electric_gripper" default="false"/>
+  <arg name="right_electric_gripper" default="true"/>
+  <arg name="left_electric_gripper" default="true"/>
   <!-- Set the kinematic tips for the left_arm and right_arm move_groups -->
   <arg name="left_tip_name" default="left_gripper"/>
   <arg name="right_tip_name" default="right_gripper"/>
   <include file="$(find baxter_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
     <arg name="left_electric_gripper" value="$(arg left_electric_gripper)"/>
     <arg name="right_electric_gripper" value="$(arg right_electric_gripper)"/>
     <arg name="left_tip_name" value="$(arg left_tip_name)"/>
     <arg name="right_tip_name" value="$(arg right_tip_name)"/>
   </include>
 
-  <node name="dummy_joint_trajectory_controller" pkg="baxter_moveit_config" type="dummy_joint_trajectory_controller">
-    <remap from="/joint_states" to="/robot/joint_states" />
-  </node>
-  
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen">
-    <remap from="/joint_states" to="/robot/joint_states" />
-  </node>
   <arg name="kinect" default="false" />
   <arg name="xtion" default="false" />
   <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>

--- a/baxter/baxter_moveit_config/launch/demo_baxter.launch
+++ b/baxter/baxter_moveit_config/launch/demo_baxter.launch
@@ -1,16 +1,23 @@
+<?xml version="1.0"?>
 <launch>
   <arg name="config" default="true"/>
   <arg name="rviz_config" default="$(find baxter_moveit_config)/launch/moveit.rviz" />
    
+  <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
+  <arg name="load_robot_description" default="false"/>
+  <!-- Left and right electric gripper params. Set to true to check for collisions for their links -->
+  <arg name="right_electric_gripper" default="false"/>
+  <arg name="left_electric_gripper" default="false"/>
+  <!-- Set the kinematic tips for the left_arm and right_arm move_groups -->
+  <arg name="left_tip_name" default="left_gripper"/>
+  <arg name="right_tip_name" default="right_gripper"/>
   <include file="$(find baxter_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
+    <arg name="left_electric_gripper" value="$(arg left_electric_gripper)"/>
+    <arg name="right_electric_gripper" value="$(arg right_electric_gripper)"/>
+    <arg name="left_tip_name" value="$(arg left_tip_name)"/>
+    <arg name="right_tip_name" value="$(arg right_tip_name)"/>
   </include>
-
-  <!--node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="false"/>
-  </node-->
-  
-  <!--node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" /-->
 
   <arg name="kinect" default="false" />
   <arg name="xtion" default="false" />
@@ -18,7 +25,7 @@
   <include file="$(find baxter_moveit_config)/launch/move_group.launch">
     <arg name="kinect" value="$(arg kinect)" />
     <arg name="xtion" value="$(arg xtion)" />
-    <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>
+    <arg name="camera_link_pose" value="$(arg camera_link_pose)"/>
     <arg name="allow_trajectory_execution" value="true"/>
   </include>
 

--- a/baxter/baxter_moveit_config/launch/demo_kinect.launch
+++ b/baxter/baxter_moveit_config/launch/demo_kinect.launch
@@ -1,7 +1,16 @@
+<?xml version="1.0"?>
 <launch>
   <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>
   <arg name="config" default="true"/>
   <arg name="rviz_config" default="$(find baxter_moveit_config)/launch/moveit.rviz" />
+  <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
+  <arg name="load_robot_description" default="false"/>
+  <!-- Left and right electric gripper params. Set to true to check for collisions for their links -->
+  <arg name="right_electric_gripper" default="false"/>
+  <arg name="left_electric_gripper" default="false"/>
+  <!-- Set the kinematic tips for the left_arm and right_arm move_groups -->
+  <arg name="left_tip_name" default="left_gripper"/>
+  <arg name="right_tip_name" default="right_gripper"/>
 
   <!-- Explicitly run moveit for baxter with the kinect -->
   <!-- Calls the demo_baxter launch file with the kinect argument set to true -->
@@ -10,6 +19,11 @@
     <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>
     <arg name="config" value="$(arg config)" />
     <arg name="rviz_config" value="$(arg rviz_config)" />
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
+    <arg name="left_electric_gripper" value="$(arg left_electric_gripper)"/>
+    <arg name="right_electric_gripper" value="$(arg right_electric_gripper)"/>
+    <arg name="left_tip_name" value="$(arg left_tip_name)"/>
+    <arg name="right_tip_name" value="$(arg right_tip_name)"/>
   </include>
 
 </launch>

--- a/baxter/baxter_moveit_config/launch/demo_xtion.launch
+++ b/baxter/baxter_moveit_config/launch/demo_xtion.launch
@@ -1,9 +1,18 @@
+<?xml version="1.0"?>
 <launch>
   <!-- Explicitly run moveit for baxter with the xtion -->
   <!-- Calls the demo_baxter launch file with the xtion argument set to true -->
 
   <arg name="config" default="true"/>
   <arg name="rviz_config" default="$(find baxter_moveit_config)/launch/moveit.rviz" />
+  <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
+  <arg name="load_robot_description" default="false"/>
+  <!-- Left and right electric gripper params. Set to true to check for collisions for their links -->
+  <arg name="right_electric_gripper" default="false"/>
+  <arg name="left_electric_gripper" default="false"/>
+  <!-- Set the kinematic tips for the left_arm and right_arm move_groups -->
+  <arg name="left_tip_name" default="left_gripper"/>
+  <arg name="right_tip_name" default="right_gripper"/>
 
   <arg name="camera_link_pose" default="0.15 0.075 0.5 0.0 0.7854 0.0"/>
   <include file="$(find baxter_moveit_config)/launch/demo_baxter.launch">
@@ -11,6 +20,11 @@
     <arg name="camera_link_pose" default="$(arg camera_link_pose)"/>
     <arg name="config" value="$(arg config)" />
     <arg name="rviz_config" value="$(arg rviz_config)" />
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
+    <arg name="left_electric_gripper" value="$(arg left_electric_gripper)"/>
+    <arg name="right_electric_gripper" value="$(arg right_electric_gripper)"/>
+    <arg name="left_tip_name" value="$(arg left_tip_name)"/>
+    <arg name="right_tip_name" value="$(arg right_tip_name)"/>
   </include>
 
 </launch>

--- a/baxter/baxter_moveit_config/launch/move_group.launch
+++ b/baxter/baxter_moveit_config/launch/move_group.launch
@@ -1,7 +1,5 @@
 <launch>
 
-  <include file="$(find baxter_moveit_config)/launch/planning_context.launch" />
-
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />

--- a/baxter/baxter_moveit_config/launch/planning_context.launch
+++ b/baxter/baxter_moveit_config/launch/planning_context.launch
@@ -1,16 +1,30 @@
+<?xml version="1.0"?>
 <launch>
+  <!-- Left and right electric gripper params. Set to true to check for collisions for their links -->
+  <arg name="right_electric_gripper" default="true"/>
+  <arg name="left_electric_gripper" default="true"/>
+  <!-- Set the kinematic tips for the left_arm and right_arm move_groups -->
+  <arg name="left_tip_name" default="left_gripper"/>
+  <arg name="right_tip_name" default="right_gripper"/>
+
   <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
   <arg name="load_robot_description" default="false"/>
 
   <!-- Load universal robotic description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="robot_description" textfile="$(find baxter_description)/urdf/baxter.urdf"/>
+  <param if="$(arg load_robot_description)" name="robot_description"
+      command="$(find xacro)/xacro.py --inorder $(find baxter_description)/urdf/baxter.urdf.xacro"/>
 
   <!-- The semantic description that corresponds to the URDF -->
-  <param name="robot_description_semantic" textfile="$(find baxter_moveit_config)/config/baxter.srdf" />
-  
+  <param name="robot_description_semantic"
+      command="$(find xacro)/xacro.py --inorder $(find baxter_moveit_config)/config/baxter.srdf.xacro
+          left_electric_gripper:=$(arg left_electric_gripper)
+          right_electric_gripper:=$(arg right_electric_gripper)
+          left_tip_name:=$(arg left_tip_name)
+          right_tip_name:=$(arg right_tip_name)"/>
+
   <!-- Load to the parameter server yaml files -->
-  <group ns="robot_description_planning">    
+  <group ns="robot_description_planning">
     <rosparam command="load" file="$(find baxter_moveit_config)/config/joint_limits.yaml"/>
   </group>
-  
+
 </launch>


### PR DESCRIPTION
`baxter.srdf.xacro` is now the new "`baxter.srdf`" (the old one is
left unchanged for backwards compatibility). The xacro creates the
standard "no-gripper" Baxter srdf by default, but can enable new
gripper collision checks if left or right_electric_gripper args are
set to true. Also, the link used as the kinematic tip for each arm
(`<side>_tip_name`) can be set at launch.

- Set the default tip name to be `<side>_gripper`
- Now a default end effector srdf takes care of the default `<side>_gripper`
  collisions
- Electric Gripper specific collisions use the correct finger link names
- Fixed a `move_group` arg value in demo_baxter
- Removed nefarious `planning_context.launch` call from `move_group.launch`
  which would overwrite all args from a previous `move_group.launch` call