### PR TITLE
set RRT as default planner

### DIFF
--- a/baxter/baxter_moveit_config/config/ompl_planning.yaml
+++ b/baxter/baxter_moveit_config/config/ompl_planning.yaml
@@ -18,6 +18,7 @@ planner_configs:
   BKPIECEkConfigDefault:
     type: geometric::BKPIECE
 left_arm:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - LBKPIECEkConfigDefault
@@ -30,6 +31,7 @@ left_arm:
   projection_evaluator: joints(left_s0,left_s1)
   longest_valid_segment_fraction: 0.05
 right_arm:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - LBKPIECEkConfigDefault
@@ -42,6 +44,7 @@ right_arm:
   projection_evaluator: joints(right_s0,right_s1)
   longest_valid_segment_fraction: 0.05
 both_arms:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - LBKPIECEkConfigDefault
@@ -54,6 +57,7 @@ both_arms:
   projection_evaluator: joints(right_s0,right_s1)
   longest_valid_segment_fraction: 0.05
 left_hand:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - LBKPIECEkConfigDefault
@@ -64,6 +68,7 @@ left_hand:
     - BKPIECEkConfigDefault
     - RRTStarkConfigDefault
 right_hand:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - LBKPIECEkConfigDefault


### PR DESCRIPTION
set default planning config, which is supported on moveit 0.7
https://github.com/ros-planning/moveit_ros/pull/625