### PR TITLE
Baxter's move_groups: torso instead of base frame

### DIFF
--- a/baxter/baxter_moveit_config/config/baxter_base.srdf.xacro
+++ b/baxter/baxter_moveit_config/config/baxter_base.srdf.xacro
@@ -13,10 +13,10 @@
     <xacro:arg name="left_tip_name" default="left_gripper"/>
     <xacro:arg name="right_tip_name" default="right_gripper"/>
     <group name="left_arm">
-        <chain base_link="base" tip_link="$(arg left_tip_name)" />
+        <chain base_link="torso" tip_link="$(arg left_tip_name)" />
     </group>
     <group name="right_arm">
-        <chain base_link="base" tip_link="$(arg right_tip_name)" />
+        <chain base_link="torso" tip_link="$(arg right_tip_name)" />
     </group>
     <group name="both_arms">
         <group name="right_arm" />


### PR DESCRIPTION
As reported in the discussion on the baxter_users forum [1],
the `both_arms` move group could only plan using one arm. This
defeated the purpose of having a `both_arms` move group that
comprised of the `left_arm` and `right_arm` move groups.

It appears that MoveIt only considered one arm group of the two to
be valid, and threw out the other group. This only occurred when
using `chains` to specify the move group, and not when enumerating
all of the `joints` (as we did in the past).

The offending the `both_arms` chains were as follows:
```
- right_arm: base->torso->right_arm_mount->...->right_gripper
- left_arm:  base->torso->left_arm_mount->....->left_gripper
```
with a null transform between base->torso. This causes the
kinematic chain handler in MoveIt to recognize the second chain
had a redundant link of `torso`. Even though this is connected by
a `fixed` link on both sides, it decides the second chain is invalid,
and eliminates it from the `both_arms` move_group. This is either a
bug or undocumented (and unwarned) functionality.

The fix is to remove the use of the `base` frame and instead use the
`torso` frame as the base_link of the kinematic chain. We lose nothing
in this since there is only a null transform between base->torso.
The resulting `both_arms` chains are as follows:
```
- right_arm: torso->right_arm_mount->...->right_gripper
- left_arm:  torso->left_arm_mount->....->left_gripper
```
and the `both_arms` move group can now move both arms simultaneously.

[1] https://groups.google.com/a/rethinkrobotics.com/forum/#!topic/brr-users/59kLdsAfR-g