### PR TITLE
Added missing dependency on lapack and blas

### DIFF
--- a/baxter/baxter_ikfast_left_arm_plugin/package.xml
+++ b/baxter/baxter_ikfast_left_arm_plugin/package.xml
@@ -23,6 +23,7 @@
     <moveit_core plugin="${prefix}/baxter_left_arm_moveit_ikfast_plugin_description.xml"/>
   </export>
 
+  <build_depend>liblapack-dev</build_depend>
   <build_depend>moveit_core</build_depend>
   <run_depend>moveit_core</run_depend>
   <build_depend>pluginlib</build_depend>

--- a/baxter/baxter_ikfast_right_arm_plugin/package.xml
+++ b/baxter/baxter_ikfast_right_arm_plugin/package.xml
@@ -24,6 +24,7 @@
     <moveit_core plugin="${prefix}/baxter_right_arm_moveit_ikfast_plugin_description.xml"/>
   </export>
 
+  <build_depend>liblapack-dev</build_depend>
   <build_depend>moveit_core</build_depend>
   <run_depend>moveit_core</run_depend>
   <build_depend>pluginlib</build_depend>


### PR DESCRIPTION
The IKFast plugins were failing in a Ubuntu 16.04 Kinetic Docker

@IanTheEngineer 