### PR TITLE
remove redundant include_directories

### DIFF
--- a/baxter/baxter_ikfast_left_arm_plugin/CMakeLists.txt
+++ b/baxter/baxter_ikfast_left_arm_plugin/CMakeLists.txt
@@ -13,9 +13,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Eigen3 REQUIRED)
 
-include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
-
 catkin_package(
   LIBRARIES
   DEPENDS

--- a/baxter/baxter_ikfast_right_arm_plugin/CMakeLists.txt
+++ b/baxter/baxter_ikfast_right_arm_plugin/CMakeLists.txt
@@ -13,9 +13,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Eigen3 REQUIRED)
 
-include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
-
 catkin_package(
   LIBRARIES
   DEPENDS


### PR DESCRIPTION
Also remove link_directories. Its use is strongly discouraged by catkin_lint.
