### PR TITLE
[baxter_ikfast_plugin] isnam -> std::isnan to fix build error

### DIFF
--- a/baxter/baxter_ikfast_left_arm_plugin/src/baxter_left_arm_ikfast_solver.cpp
+++ b/baxter/baxter_ikfast_left_arm_plugin/src/baxter_left_arm_ikfast_solver.cpp
@@ -165,21 +165,21 @@ inline double IKtan(double f) { return tan(f); }
 inline float IKsqrt(float f) { if( f <= 0.0f ) return 0.0f; return sqrtf(f); }
 inline double IKsqrt(double f) { if( f <= 0.0 ) return 0.0; return sqrt(f); }
 inline float IKatan2(float fy, float fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
+    if( std::isnan(fy) ) {
+        IKFAST_ASSERT(!std::isnan(fx)); // if both are nan, probably wrong value will be returned
         return float(IKPI_2);
     }
-    else if( isnan(fx) ) {
+    else if( std::isnan(fx) ) {
         return 0;
     }
     return atan2f(fy,fx);
 }
 inline double IKatan2(double fy, double fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
+    if( std::isnan(fy) ) {
+        IKFAST_ASSERT(!std::isnan(fx)); // if both are nan, probably wrong value will be returned
         return IKPI_2;
     }
-    else if( isnan(fx) ) {
+    else if( std::isnan(fx) ) {
         return 0;
     }
     return atan2(fy,fx);

--- a/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp
+++ b/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp
@@ -165,21 +165,21 @@ inline double IKtan(double f) { return tan(f); }
 inline float IKsqrt(float f) { if( f <= 0.0f ) return 0.0f; return sqrtf(f); }
 inline double IKsqrt(double f) { if( f <= 0.0 ) return 0.0; return sqrt(f); }
 inline float IKatan2(float fy, float fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
+    if( std::isnan(fy) ) {
+        IKFAST_ASSERT(!std::isnan(fx)); // if both are nan, probably wrong value will be returned
         return float(IKPI_2);
     }
-    else if( isnan(fx) ) {
+    else if( std::isnan(fx) ) {
         return 0;
     }
     return atan2f(fy,fx);
 }
 inline double IKatan2(double fy, double fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
+    if( std::isnan(fy) ) {
+        IKFAST_ASSERT(!std::isnan(fx)); // if both are nan, probably wrong value will be returned
         return IKPI_2;
     }
-    else if( isnan(fx) ) {
+    else if( std::isnan(fx) ) {
         return 0;
     }
     return atan2(fy,fx);


### PR DESCRIPTION
Related to #55
it cause build error as below
```
[baxter_ikfast_right_arm_plugin] In file included from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:112:0:
[baxter_ikfast_right_arm_plugin] /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp: In function double ikfast_kinematics_plugin::IKatan2(double, double):
[baxter_ikfast_right_arm_plugin] /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp:178:17: error:call of overloaded isnan(double&) is ambiguous
[baxter_ikfast_right_arm_plugin]      if( isnan(fy) ) {
[baxter_ikfast_right_arm_plugin]                  ^
[baxter_ikfast_right_arm_plugin] /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp:178:17: note: candidates are:
[baxter_ikfast_right_arm_plugin] In file included from /usr/include/math.h:69:0,
[baxter_ikfast_right_arm_plugin]                  from /usr/include/c++/4.9/cmath:44,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/time.h:55,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/ros.h:38,
[baxter_ikfast_right_arm_plugin]                  from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:48:
[baxter_ikfast_right_arm_plugin] /usr/include/x86_64-linux-gnu/bits/mathcalls.h:234:12: note: int isnan(double)
[baxter_ikfast_right_arm_plugin]  __MATHDECL_1 (int,isnan,, (_Mdouble_ __value)) __attribute__ ((__const__));
[baxter_ikfast_right_arm_plugin]             ^
[baxter_ikfast_right_arm_plugin] In file included from /opt/ros/indigo/include/ros/time.h:55:0,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/ros.h:38,
[baxter_ikfast_right_arm_plugin]                  from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:48:
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:634:3: note: constexpr bool std::isnan(long double)
[baxter_ikfast_right_arm_plugin]    isnan(long double __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:630:3: note: constexpr bool std::isnan(double)
[baxter_ikfast_right_arm_plugin]    isnan(double __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:626:3: note: constexpr bool std::isnan(float)
[baxter_ikfast_right_arm_plugin]    isnan(float __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] In file included from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:112:0:
[baxter_ikfast_right_arm_plugin] /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp:179:26: error:call of overloaded isnan(double&) is ambiguous
[baxter_ikfast_right_arm_plugin]          IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
[baxter_ikfast_right_arm_plugin]                           ^
[baxter_ikfast_right_arm_plugin] /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp:179:26: note: candidates are:
[baxter_ikfast_right_arm_plugin] In file included from /usr/include/math.h:69:0,
[baxter_ikfast_right_arm_plugin]                  from /usr/include/c++/4.9/cmath:44,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/time.h:55,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/ros.h:38,
[baxter_ikfast_right_arm_plugin]                  from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:48:
[baxter_ikfast_right_arm_plugin] /usr/include/x86_64-linux-gnu/bits/mathcalls.h:234:12: note: int isnan(double)
[baxter_ikfast_right_arm_plugin]  __MATHDECL_1 (int,isnan,, (_Mdouble_ __value)) __attribute__ ((__const__));
[baxter_ikfast_right_arm_plugin]             ^
[baxter_ikfast_right_arm_plugin] In file included from /opt/ros/indigo/include/ros/time.h:55:0,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/ros.h:38,
[baxter_ikfast_right_arm_plugin]                  from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:48:
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:634:3: note: constexpr bool std::isnan(long double)
[baxter_ikfast_right_arm_plugin]    isnan(long double __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:630:3: note: constexpr bool std::isnan(double)
[baxter_ikfast_right_arm_plugin]    isnan(double __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:626:3: note: constexpr bool std::isnan(float)
[baxter_ikfast_right_arm_plugin]    isnan(float __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] In file included from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:112:0:
[baxter_ikfast_right_arm_plugin] /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp:182:22: error:call of overloaded isnan(double&) is ambiguous
[baxter_ikfast_right_arm_plugin]      else if( isnan(fx) ) {
[baxter_ikfast_right_arm_plugin]                       ^
[baxter_ikfast_right_arm_plugin] /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_solver.cpp:182:22: note: candidates are:
[baxter_ikfast_right_arm_plugin] In file included from /usr/include/math.h:69:0,
[baxter_ikfast_right_arm_plugin]                  from /usr/include/c++/4.9/cmath:44,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/time.h:55,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/ros.h:38,
[baxter_ikfast_right_arm_plugin]                  from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:48:
[baxter_ikfast_right_arm_plugin] /usr/include/x86_64-linux-gnu/bits/mathcalls.h:234:12: note: int isnan(double)
[baxter_ikfast_right_arm_plugin]  __MATHDECL_1 (int,isnan,, (_Mdouble_ __value)) __attribute__ ((__const__));
[baxter_ikfast_right_arm_plugin]             ^
[baxter_ikfast_right_arm_plugin] In file included from /opt/ros/indigo/include/ros/time.h:55:0,
[baxter_ikfast_right_arm_plugin]                  from /opt/ros/indigo/include/ros/ros.h:38,
[baxter_ikfast_right_arm_plugin]                  from /home/shingo/ros/indigo/src/moveit_robots/baxter/baxter_ikfast_right_arm_plugin/src/baxter_right_arm_ikfast_moveit_plugin.cpp:48:
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:634:3: note: constexpr bool std::isnan(long double)
[baxter_ikfast_right_arm_plugin]    isnan(long double __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:630:3: note: constexpr bool std::isnan(double)
[baxter_ikfast_right_arm_plugin]    isnan(double __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] /usr/include/c++/4.9/cmath:626:3: note: constexpr bool std::isnan(float)
[baxter_ikfast_right_arm_plugin]    isnan(float __x)
[baxter_ikfast_right_arm_plugin]    ^
[baxter_ikfast_right_arm_plugin] make[2]: *** [CMakeFiles/baxter_right_arm_moveit_ikfast_plugin.dir/src/baxter_right_arm_ikfast_moveit_plugin.cpp.o]  1
[baxter_ikfast_right_arm_plugin] make[1]: *** [CMakeFiles/baxter_right_arm_moveit_ikfast_plugin.dir/all]  2
[baxter_ikfast_right_arm_plugin] make: *** [all]  2
[baxter_ikfast_right_arm_plugin] <== '/home/shingo/ros/indigo/build/baxter_ikfast_right_arm_plugin/build_env.sh /usr/bin/make --jobserver-fds=3,5 -j' failed with return code '2'
Failed   <== baxter_ikfast_right_arm_plugin [ 5.0 seconds ]
[build] There were '1' errors:
```